### PR TITLE
Add description to optional parameters

### DIFF
--- a/ModernRonin.FluentArgumentParser.Tests/Parsing/ParameterBindingConfigurerTests.cs
+++ b/ModernRonin.FluentArgumentParser.Tests/Parsing/ParameterBindingConfigurerTests.cs
@@ -243,4 +243,16 @@ public class ParameterBindingConfigurerTests
 
         underTest.WithShortName("alpha").Should().BeSameAs(underTest);
     }
+
+    [Test]
+    public void WithDescription_Should_Set_Description()
+    {
+        string value = "testDescription";
+        var parameter = new OptionalParameter();
+        var underTest = new ParameterBindingConfigurer<string>(() => parameter, _ => { });
+
+        underTest.WithDefaultDescription(value);
+
+        parameter.Description.Should().Be(value);
+    }
 }

--- a/ModernRonin.FluentArgumentParser.Tests/Validation/OptionalParameterValidatorTests.cs
+++ b/ModernRonin.FluentArgumentParser.Tests/Validation/OptionalParameterValidatorTests.cs
@@ -1,7 +1,11 @@
 ﻿using FluentValidation.TestHelper;
+
 using ModernRonin.FluentArgumentParser.Definition;
 using ModernRonin.FluentArgumentParser.Validation;
+
 using NUnit.Framework;
+
+using System;
 
 namespace ModernRonin.FluentArgumentParser.Tests.Validation;
 
@@ -10,6 +14,19 @@ public class OptionalParameterValidatorTests
 {
     [Test]
     public void HasDefaultBeenSet_must_be_true() =>
-        new OptionalParameterValidator().TestValidate(new OptionalParameter { Type = typeof(string) })
+        new OptionalParameterValidator()
+        .TestValidate(new OptionalParameter { Type = typeof(string) })
             .ShouldHaveValidationErrorFor(p => p.Default);
+
+    [Test]
+    public void Description_Should_Have_Error_When_Description_Empty_For_Reference_Type() =>
+        new OptionalParameterValidator()
+            .TestValidate(new OptionalParameter { Type = typeof(string) })
+            .ShouldHaveValidationErrorFor(p => p.Description);
+
+    [Test]
+    public void Description_Should_Not_Have_Error_When_Description_Empty_For_Value_Type() =>
+        new OptionalParameterValidator()
+            .TestValidate(new OptionalParameter { Type = typeof(int) })
+            .ShouldHaveValidationErrorFor(p => p.Description);
 }

--- a/ModernRonin.FluentArgumentParser/Definition/OptionalParameter.cs
+++ b/ModernRonin.FluentArgumentParser/Definition/OptionalParameter.cs
@@ -3,7 +3,17 @@
 public class OptionalParameter : AnIndexableParameter
 {
     object _default;
+    string _description;
     public bool HasDefaultBeenSet { get; private set; }
+
+    public string Description
+    {
+        get => string.IsNullOrEmpty(_description) ? $"default: {_default}": _description;
+        set
+        {
+            _description = $"default: {value} ({_default})";
+        }
+    }
 
     public object Default
     {

--- a/ModernRonin.FluentArgumentParser/Definition/OptionalParameter.cs
+++ b/ModernRonin.FluentArgumentParser/Definition/OptionalParameter.cs
@@ -3,17 +3,8 @@
 public class OptionalParameter : AnIndexableParameter
 {
     object _default;
-    string _description;
     public bool HasDefaultBeenSet { get; private set; }
-
-    public string Description
-    {
-        get => string.IsNullOrEmpty(_description) ? $"default: {_default}": _description;
-        set
-        {
-            _description = $"default: {value} ({_default})";
-        }
-    }
+    public string Description { get; set; }
 
     public object Default
     {

--- a/ModernRonin.FluentArgumentParser/Help/HelpMaker.cs
+++ b/ModernRonin.FluentArgumentParser/Help/HelpMaker.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+
 using ModernRonin.FluentArgumentParser.Definition;
 using ModernRonin.FluentArgumentParser.Extensibility;
 using ModernRonin.FluentArgumentParser.Parsing;
+
 using MoreLinq.Extensions;
 
 namespace ModernRonin.FluentArgumentParser.Help;
@@ -184,7 +186,14 @@ public class HelpMaker : IHelpMaker
         Row optionalToRow(OptionalParameter opt)
         {
             var result = indexableToRow(opt);
-            result.RightLines.Add(opt.Description);
+            if (opt.Default == null)
+            {
+                result.RightLines.Add(opt.Description);
+            }
+            else
+            {
+                result.RightLines.Add($"Default: {opt.Default}");
+            }
             return result;
         }
 
@@ -219,10 +228,10 @@ public class HelpMaker : IHelpMaker
         addDescription();
         Line("Available commands:");
         Table(materialized.Select(v => new Row
-            {
-                LeftText = v.Name,
-                RightLines = { v.HelpText }
-            })
+        {
+            LeftText = v.Name,
+            RightLines = { v.HelpText }
+        })
             .ToArray());
         LineFeed();
         Line("use help <command> for more detailed help on a specific command");

--- a/ModernRonin.FluentArgumentParser/Help/HelpMaker.cs
+++ b/ModernRonin.FluentArgumentParser/Help/HelpMaker.cs
@@ -184,7 +184,7 @@ public class HelpMaker : IHelpMaker
         Row optionalToRow(OptionalParameter opt)
         {
             var result = indexableToRow(opt);
-            result.RightLines.Add($"default: {opt.Default}");
+            result.RightLines.Add(opt.Description);
             return result;
         }
 

--- a/ModernRonin.FluentArgumentParser/Parsing/ParameterBindingConfigurer.cs
+++ b/ModernRonin.FluentArgumentParser/Parsing/ParameterBindingConfigurer.cs
@@ -120,4 +120,23 @@ public sealed class ParameterBindingConfigurer<TProperty>
         Parameter.HelpText = helpText;
         return this;
     }
+
+    /// <summary>
+    ///     <para>
+    ///     Set default description for optional parameter.
+    ///     </para>
+    ///     Default description is required for reference types with a default value of null
+    /// </summary>
+    /// <exception cref="InvalidOperationException"></exception>
+    public ParameterBindingConfigurer<TProperty> WithDefaultDescription(string text)
+    {
+        if (!(Parameter is OptionalParameter optional))
+        {
+            throw new InvalidOperationException(
+                $"Default are only settable for optional parameters - maybe you forgot a call to {nameof(MakeOptional)}?");
+        }
+
+        optional.Description = text;
+        return this;
+    }
 }

--- a/ModernRonin.FluentArgumentParser/Validation/OptionalParameterValidator.cs
+++ b/ModernRonin.FluentArgumentParser/Validation/OptionalParameterValidator.cs
@@ -12,12 +12,7 @@ public class OptionalParameterValidator : AbstractValidator<OptionalParameter>
         RuleFor(p => p.Default).Must((p, _) => p.HasDefaultBeenSet);
         RuleFor(p => p.Description).Must((p, _) =>
         {
-            if (!p.HasDefaultBeenSet)
-            {
-                return false;
-            }
-
-            if (p.Default.GetType().DefaultValue == null)
+            if (p.Default is null && string.IsNullOrEmpty(p.Description))
             {
                 return false;
             }

--- a/ModernRonin.FluentArgumentParser/Validation/OptionalParameterValidator.cs
+++ b/ModernRonin.FluentArgumentParser/Validation/OptionalParameterValidator.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+
 using ModernRonin.FluentArgumentParser.Definition;
 
 namespace ModernRonin.FluentArgumentParser.Validation;
@@ -9,5 +10,19 @@ public class OptionalParameterValidator : AbstractValidator<OptionalParameter>
     {
         Include(new IndexableParameterValidator());
         RuleFor(p => p.Default).Must((p, _) => p.HasDefaultBeenSet);
+        RuleFor(p => p.Description).Must((p, _) =>
+        {
+            if (!p.HasDefaultBeenSet)
+            {
+                return false;
+            }
+
+            if (p.Default.GetType().DefaultValue == null)
+            {
+                return false;
+            }
+
+            return true;
+        }).WithMessage("Reference types (with a null default) requires a description to be set.");
     }
 }


### PR DESCRIPTION
Add description for optional parameters. If the property type has a default value of `null`, throw an error saying description is required.